### PR TITLE
Update _variables.scss with $unit-intervals

### DIFF
--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -111,6 +111,13 @@ $max-width-center-container: 1200px;
 $gutter: 15px;
 $padding-container: 0 $gutter;
 
+$unit-intervals: (
+  'px': 0.02,
+  'em': 0.01,
+  'rem': 0.1,
+  '': 0
+);
+
 // grid sistem
 $grid: (
     ph: 'phone',


### PR DESCRIPTION
And it was in previous versions, but now it isn't. Why?